### PR TITLE
specify go patch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22 as builder
+FROM golang:1.22.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.5 AS builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/undistro/kubexns
 
-go 1.22.0
+go 1.22.5
 
 require (
 	k8s.io/api v0.30.0


### PR DESCRIPTION
## Description
This PR specifies Go patch version 1.22.5 to avoid some vulnerabilities

Before:
```
trivy image --scanners vuln ghcr.io/undistro/kubexns:v0.1.4
2024-07-31T10:35:43-03:00       INFO    Vulnerability scanning is enabled
2024-07-31T10:35:47-03:00       INFO    Detected OS     family="debian" version="12.5"
2024-07-31T10:35:47-03:00       INFO    [debian] Detecting vulnerabilities...   os_version="12" pkg_num=3
2024-07-31T10:35:47-03:00       INFO    Number of language-specific files       num=1
2024-07-31T10:35:47-03:00       INFO    [gobinary] Detecting vulnerabilities...

ghcr.io/undistro/kubexns:v0.1.4 (debian 12.5)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


kubexns (gobinary)

Total: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 1, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.22.2            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for   │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24788 │ HIGH     │        │                   │ 1.22.3          │ golang: net: malformed DNS message can cause infinite loop   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24788                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24789 │ MEDIUM   │        │                   │ 1.21.11, 1.22.4 │ golang: archive/zip: Incorrect handling of certain ZIP files │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24789                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24791 │          │        │                   │ 1.21.12, 1.22.5 │ net/http: Denial of service due to improper 100-continue     │
│         │                │          │        │                   │                 │ handling in net/http                                         │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24791                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```

After:
```
trivy image --scanners vuln ghcr.io/undistro/kubexns:latest
2024-07-31T10:40:02-03:00       INFO    Vulnerability scanning is enabled
2024-07-31T10:40:03-03:00       INFO    Detected OS     family="debian" version="11.7"
2024-07-31T10:40:03-03:00       INFO    [debian] Detecting vulnerabilities...   os_version="11" pkg_num=3
2024-07-31T10:40:03-03:00       INFO    Number of language-specific files       num=1
2024-07-31T10:40:03-03:00       INFO    [gobinary] Detecting vulnerabilities...

ghcr.io/undistro/kubexns:latest (debian 11.7)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## Linked Issues

## How has this been tested?
Building a docker image `make docker-build` and scanning with Trivy `trivy image --scanners vuln ghcr.io/undistro/kubexns:latest`

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
